### PR TITLE
Fix: Update git clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You'll need [Docker](https://www.docker.com/get-started) and [Docker Compose](ht
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/loki-messenger/loki-messenger.git
+    git clone https://github.com/SwedishMaria/loki-messenger.git
     cd loki-messenger
     ```
 2.  **Set up environment variables:**


### PR DESCRIPTION
The git clone URL in the README.md file was incorrect. This commit updates the URL to point to the correct repository as you provided.